### PR TITLE
Block unexpected workflow commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,25 @@
 const fs = require("fs");
+const crypto = require("crypto");
+
+const resumeToken = crypto.randomBytes(30).toString("base64")
 
 // Output environment variables. Secrets are automatically masked.
 console.log("::group::Environment variables")
+console.log(`::stop-commands::${resumeToken}`)
+
 for (const [key, value] of Object.entries(process.env).sort()) {
   console.log(`${key}=${value}`);
 }
+
+console.log(`::${resumeToken}::`)
 console.log("::endgroup::")
 
 // Output prettified event JSON.
 console.log("::group::Event JSON")
+console.log(`::stop-commands::${resumeToken}`)
+
 const event = JSON.parse(fs.readFileSync(process.env["GITHUB_EVENT_PATH"]));
 console.log(JSON.stringify(event, null, 2));
+
+console.log(`::${resumeToken}::`)
 console.log("::endgroup::")


### PR DESCRIPTION
Currently the environment and event payload are printed while workflow command processing is active. If the printed text contains workflow commands these will be handled by the runner. 

That can happen if, for example, someone copies workflow log output into an issue comment:
```text
CI is failing with `##[error]Process completed with exit code 1`...
```

This PR prevents that by [switching off command processing](https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#stopping-and-starting-workflow-commands) while printing.