### PR TITLE
bump to node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,5 +4,5 @@ branding:
   icon: 'code'
   color: 'yellow'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
to avoid this warning:

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: hmarr/debug-action
```

Should probably be a new major version.