### PR TITLE
bump to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,5 +4,5 @@ branding:
   icon: 'code'
   color: 'yellow'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'


### PR DESCRIPTION
Hello again!

to avoid this warning:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: hmarr/debug-action@v2
```

Should probably be a new major version.