### PR TITLE
Update Node version from 20 to 24 in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,5 +4,5 @@ branding:
   icon: 'code'
   color: 'yellow'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'


### PR DESCRIPTION
This pull request updates the Node.js runtime version used by the GitHub Action from Node 20 to Node 24 in the `action.yml` configuration file.

Fixes #9

See Also: [GitHub Blog - Deprecation of Node 20 on GitHub Actions Runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)